### PR TITLE
Keep headers from "old" response

### DIFF
--- a/src/Middleware/OAuthExceptionHandlerMiddleware.php
+++ b/src/Middleware/OAuthExceptionHandlerMiddleware.php
@@ -46,7 +46,7 @@ class OAuthExceptionHandlerMiddleware
                 'error_description' => $e->getMessage(),
             ];
 
-            return new JsonResponse($data, $e->httpStatusCode, $e->getHttpHeaders());
+            return new JsonResponse($data, $e->httpStatusCode, array_merge($response->headers->all(), $e->getHttpHeaders()));
         }
     }
 }


### PR DESCRIPTION
Keeping the old headers is useful if e.g. an other middleware adds cors-headers.
